### PR TITLE
Remove products_id from ajax request

### DIFF
--- a/Installation files/includes/classes/dynamic_price_updater.php
+++ b/Installation files/includes/classes/dynamic_price_updater.php
@@ -768,6 +768,10 @@ class DPU extends base {
   function setCurrentPage() {
     global $db, $request_type;
 
+    if (empty($_GET['products_id'])) {
+      $_GET['products_id'] = !empty($_POST['products_id']) ? $_POST['products_id'] : 0;
+    }
+
     if (isset($_SESSION['customer_id']) && $_SESSION['customer_id']) {
       $wo_customer_id = $_SESSION['customer_id'];
 

--- a/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
+++ b/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
@@ -149,7 +149,7 @@ objXHR.prototype.getData = function(strMode, resFunc, combinedData) { // send a 
         }
       };
 
-      this.XHR.open(strMode.toLowerCase(), theURL + "<?php echo zen_decode_specialchars(substr(zen_href_link($theURL, zen_get_all_get_params(array('action','pid')) . (!empty($_GET['main_page']) && zen_not_null($_GET['main_page']) ? 'main_page=' . zen_output_string_protected($_GET['main_page']) . '&' : '') . 'act=DPU_Ajax&method=dpu_update', $request_type, true, true, true, false), strlen($theURL) + strlen(($request_type == 'SSL' && defined('HTTPS_SERVER') ? HTTPS_SERVER : HTTP_SERVER)))); ?>" + (strMode.toLowerCase() === "get" ? "&" + this.compileRequest() : ""), true);
+      this.XHR.open(strMode.toLowerCase(), theURL + "<?php echo zen_decode_specialchars(substr(zen_href_link($theURL, 'act=DPU_Ajax&method=dpu_update', $request_type, true, true, true, false), strlen($theURL) + strlen(($request_type == 'SSL' && defined('HTTPS_SERVER') ? HTTPS_SERVER : HTTP_SERVER)))); ?>" + (strMode.toLowerCase() === "get" ? "&" + this.compileRequest() : ""), true);
    
 /*                        this.XHR.open(strMode.toLowerCase(), this.url+"?act=DPU_Ajax&method=dpu_update"+(strMode.toLowerCase() == "get" ? "&" + this.compileRequest() : ""), true);*/
       if (strMode.toLowerCase() === "post") {
@@ -159,7 +159,7 @@ objXHR.prototype.getData = function(strMode, resFunc, combinedData) { // send a 
       this.XHR.send(combinedData.XML);
     } else {
       var option = {
-          url: theURL + "<?php echo zen_decode_specialchars(substr(zen_href_link($theURL, zen_get_all_get_params(array('action','pid')) . (!empty($_GET['main_page']) && zen_not_null($_GET['main_page']) ? 'main_page=' . zen_output_string_protected($_GET['main_page']) . '&' : '') . 'product_info&act=DPU_Ajax&method=dpu_update', $request_type, true, true, true, false), strlen($theURL) + strlen(($request_type == 'SSL' && defined('HTTPS_SERVER') ? HTTPS_SERVER : HTTP_SERVER)))); ?>",
+          url: theURL + "<?php echo zen_decode_specialchars(substr(zen_href_link($theURL, 'product_info&act=DPU_Ajax&method=dpu_update', $request_type, true, true, true, false), strlen($theURL) + strlen(($request_type == 'SSL' && defined('HTTPS_SERVER') ? HTTPS_SERVER : HTTP_SERVER)))); ?>",
                     data: combinedData.JSON,
                      timeout : 30000
                    };


### PR DESCRIPTION
As a result of other changes to ZC, providing only the
products_id without a main_page when calling the ajax
command results in continuous reload of the page.  The
products_id is provided in other ways and can be used
to accomplish the same task which has been to update
the who's online information to show the page on which
the customer is visiting rather than just the call to
the associated ajax parameters.

Fixes #21